### PR TITLE
msm8960: Squashed fixes for O

### DIFF
--- a/hal/msm8960/platform.c
+++ b/hal/msm8960/platform.c
@@ -421,13 +421,6 @@ int platform_set_snd_device_acdb_id(snd_device_t snd_device __unused,
     return -ENODEV;
 }
 
-int platform_get_default_app_type_v2(void *platform, usecase_type_t type __unused,
-                                     int *app_type __unused)
-{
-    ALOGE("%s: Not implemented", __func__);
-    return -ENOSYS;
-}
-
 int platform_get_snd_device_acdb_id(snd_device_t snd_device __unused)
 {
     ALOGE("%s: Not implemented", __func__);
@@ -1104,15 +1097,17 @@ int platform_get_snd_device_name_extn(void *platform __unused,
     return 0;
 }
 
-bool platform_check_and_set_playback_backend_cfg(struct audio_device* adev __unused,
+bool platform_check_and_set_capture_backend_cfg (struct audio_device* adev __unused,
                                               struct audio_usecase *usecase __unused,
                                               snd_device_t snd_device __unused)
 {
     return false;
 }
 
-bool platform_check_and_set_capture_backend_cfg(struct audio_device* adev __unused,
-                                              struct audio_usecase *usecase __unused)
+
+bool platform_check_and_set_playback_backend_cfg(struct audio_device* adev __unused,
+                                              struct audio_usecase *usecase __unused,
+                                              snd_device_t snd_device __unused)
 {
     return false;
 }
@@ -1133,3 +1128,11 @@ int platform_snd_card_update(void *platform __unused,
 {
     return -1;
 }
+
+int platform_get_default_app_type_v2(void *platform __unused, usecase_type_t type __unused,
+                                     int *app_type __unused)
+{
+    ALOGE("%s: Not implemented", __func__);
+    return -ENOSYS;
+}
+

--- a/hal/msm8960/platform.h
+++ b/hal/msm8960/platform.h
@@ -92,6 +92,9 @@ enum {
 
 };
 
+#define DEVICE_NAME_MAX_SIZE   128
+#define HW_INFO_ARRAY_MAX_SIZE 32
+
 #define MIXER_CARD 0
 #define SOUND_CARD 0
 #define MIXER_PATH_MAX_LENGTH 100
@@ -121,6 +124,11 @@ enum {
 #define LOW_LATENCY_CAPTURE_SAMPLE_RATE 48000
 #define LOW_LATENCY_CAPTURE_PERIOD_SIZE 240
 #define LOW_LATENCY_CAPTURE_USE_CASE 0
+
+#define HFP_ASM_RX_TX 24
+
+#define PLATFORM_INFO_XML_PATH          "/system/etc/audio_platform_info.xml"
+#define PLATFORM_INFO_XML_BASE_STRING   "/system/etc/audio_platform_info"
 
 #define AFE_PROXY_PLAYBACK_PCM_DEVICE 7
 #define AFE_PROXY_RECORD_PCM_DEVICE 8


### PR DESCRIPTION
msm8960: fixes for N

* fixup of 4ed66e62279001cd62e5acec53f3e1cf5d64e77d for 8960
* port across a few constants from de4849cee04a23ae84da96487e344f75f93e5585
  to get 8960 building.

Change-Id: I98bbf5843d9b93ba1263e36a0ad64ea596cec244

msm8960: define HFP_ASM_RX_TX 24

Taken from hardware/qcom/audio-car/msm8960/hal/msm8969/platform.h
Fixes build error from android-7.1.2_r2 merge:
hardware/qcom/audio/default/hal/audio_extn/utils.c:150:25:
error: use of undeclared identifier 'HFP_ASM_RX_TX'
        pcm_device_id = HFP_ASM_RX_TX;

Change-Id: I6434c31b0310be87fa7c2128da5d641898787c4f

msm8960: Partial revert of the following
commit dd38c5fa56d4a646e2720160ba26019cef0d163b